### PR TITLE
Remove unused default features from memchr.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ nightly = []
 
 [dependencies]
 cfg-if = "0.1"
-memchr = "2"
+memchr = { version = "2", default-features = false }


### PR DESCRIPTION
Less to compile and all that jazz. Great idea for a tiny library by the way.